### PR TITLE
Allow hostname to be set manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Add the following to your `config/initializers/peek.rb`:
 Peek.into Peek::Views::Host
 ```
 
+Optionally, you can set the host manually (e.g via an environment variable)
+for use in containerized environments.
+
+```ruby
+Peek.into Peek::Views::Host, :host => ENV["HOSTNAME"]
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/peek-host/version.rb
+++ b/lib/peek-host/version.rb
@@ -1,5 +1,5 @@
 module Peek
   module Host
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end

--- a/lib/peek/views/host.rb
+++ b/lib/peek/views/host.rb
@@ -4,11 +4,11 @@ module Peek
       
       # Returns Peek::Views::Host
       def initialize(options = {})
-        @hostname = hostname
+        @hostname = options[:host]
       end
 
       def hostname
-        `hostname`
+        @hostname || `hostname`
       end
     end
   end


### PR DESCRIPTION
This allows people using the peek view in environments such as Heroku or Dokku to show the hostname of the machine the app is running on.